### PR TITLE
Fix the transaction flip logic

### DIFF
--- a/mint.js
+++ b/mint.js
@@ -62,7 +62,7 @@ async function init() {
   console.log("importing transactions");
   for (i=0; i<json.length;i++){
     let trans = json[i];
-    let flip = json[i].TransactionType==="credit" ? true : false;
+    let flip = json[i].TransactionType==="debit" ? true : false;
     let amount = api.utils.amountToInteger(
       flip ? trans.Amount*-1 : trans.Amount
     );


### PR DESCRIPTION
To ensure that deposits and payments are displayed correctly

The transactions we multiply by -1 should be debits, not credits