### PR TITLE
Switch to csv-parse to improve supported csv formats

### DIFF
--- a/mint.js
+++ b/mint.js
@@ -10,9 +10,19 @@ let cache = "./cache"; // this is where the budget file will be stored during th
 //////////////////////////////////////////////////////////
 
 let api = require('@actual-app/api');
-let csvToJson = require('convert-csv-to-json');
+const csvToJson = require('csv-parse/sync');
+const fs = require('fs');
 
-let json = csvToJson.fieldDelimiter(',').getJsonFromCsv(inFile);
+const json = csvToJson.parse(fs.readFileSync(inFile, 'utf8'), {
+  bom: true,
+  quote: '"',
+  trim: true,
+  relax_column_count: true,
+  skip_empty_lines: true,
+  columns: header => {
+    return header.map(column => column.replace(/\s+/g, ''));
+  }
+});
 
 async function init() {
   console.log("connect");

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@actual-app/api": "^6.2.1",
-        "convert-csv-to-json": "^2.0.0"
+        "csv-parse": "^5.5.2"
       }
     },
     "node_modules/@actual-app/api": {
@@ -88,10 +88,10 @@
       "version": "1.1.4",
       "license": "ISC"
     },
-    "node_modules/convert-csv-to-json": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-csv-to-json/-/convert-csv-to-json-2.0.0.tgz",
-      "integrity": "sha512-pMDclso1Afm8tGsJfcVqay10WSPgpoGKGoHdIXWIMXJX29qayEC/MlAsd6csYr59mUjLoJxpkHi37cTUSaNUpw=="
+    "node_modules/csv-parse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.2.tgz",
+      "integrity": "sha512-YRVtvdtUNXZCMyK5zd5Wty1W6dNTpGKdqQd4EQ8tl/c6KW1aMBB1Kg1ppky5FONKmEqGJ/8WjLlTNLPne4ioVA=="
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "@actual-app/api": "^6.2.1",
-    "convert-csv-to-json": "^2.0.0"
+    "csv-parse": "^5.5.2"
   }
 }


### PR DESCRIPTION
Fix for raw mint export csv, that use quotes around all data.

Switch from `convert-csv-to-json` to `csv-parse`. There is a quote handling config for convert-to-json but it doesn't apply to the header row. And csv-parse is used by actual, so I went ahead and matched the options from the actual server `parse-file.ts`.

### Why

I discovered that the sample data I had provided, did not quite match the mint export data. In data direct from mint there are quotes around all fields, including headers. (my sanitation effort ended up cleaning those up when saving the sample data).

Here is a tiny sample from the actual export that I sanitised by hand:

```
$ head -2 transactions.csv 
"Date","Description","Original Description","Amount","Transaction Type","Category","Account Name","Labels","Notes"
"7/15/2019","Debit RESP.AUTO.010101010101","Debit RESP.AUTO.010101010101","200.00","debit","Financial","Free Chequing Free Debit XXXXXXXX0000","",""
```