### PR TITLE
Allow configuration via env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,25 @@ To run the script I had the following setup:
 2. Clone this repo, and cd into it
 3. Store csv file in this directory that you exported from Mint.com
 4. run `npm install`.  (I tested with node18)
-5. Edit all the variables at the top of the file to match your setup.  You will need to use the sync_id from your budget file.  That can be found in settings->Advanced Settings->IDs
-6. run `node mint.js`
+5. Find all the [configuration](#configuration) to match your setup. Provide them in the next step.
+6. run `ACTUAL_SEVER_PASSWORD="your-password" ACTUAL_SYNC_ID="your-sync-id" node mint.js`
 
 The importer does the following:
 * All categories listed in the CSV export will be created under a category group "Mint Import"
+
+### Configuration
+
+The following environment variables are available.
+
+| Name | Description | Default |
+| ---- | ----------- | ------- |
+| ACTUAL_SERVER_URL | url of your server that the script can use to access your budget files | `http://localhost:5006`
+| ACTUAL_SERVER_PASSWORD | password of your server | |
+| ACTUAL_SYNC_ID | The sync_id from your budget file.  That can be found in settings->Advanced Settings->IDs, looks something like 'ace017dc-ee96-4b24-a1f4-e6db10c96e53' | |
+| IMPORTER_INFILE | path to mint transaction file | `transactions.csv` |
+| IMPORTER_CACHE_DIR | this is where the budget file will be stored during the import. | `./cache` |
+| IMPORTER_INCOME_CATEGORIES | comma separated list of categories to consider as income to budget | `Paycheck,Investment,Returned Purchase,Bonus,Interest Income,Reimbursement,Rental Income`
+| IMPORTER_EXTRA_INCOME_CATEGORIES | comma separated list of extra categories to add the default list | |
 
 # Budget Options
 

--- a/mint.js
+++ b/mint.js
@@ -1,13 +1,13 @@
 //////////////////////////////////////////////////////////
 // Change these to match your setup
 //////////////////////////////////////////////////////////
-let url = "http://localhost:5006"; //url of your server that the script can use to access your budget files
-let password = "your_password"; //password of your server
-let sync_id = ''; // found in advanced settings in  actualbudget, looks something like 'ace017dc-ee96-4b24-a1f4-e6db10c96e53'
-let inFile = "mint_test.csv"; //path to file
-let cache = "./cache"; // this is where the budget file will be stored during the import.  You can delete after
+let url = process.env.ACTUAL_SERVER_URL || "http://localhost:5006"; //url of your server that the script can use to access your budget files
+let password = process.env.ACTUAL_SERVER_PASSWORD || ""; //password of your server
+let sync_id = process.env.ACTUAL_SYNC_ID || ''; // found in advanced settings in  actualbudget, looks something like 'ace017dc-ee96-4b24-a1f4-e6db10c96e53'
+let inFile = process.env.IMPORTER_INFILE || "transactions.csv"; //path to file
+let cache = process.env.IMPORTER_CACHE_DIR || "./cache"; // this is where the budget file will be stored during the import.  You can delete after
 // categories to consider as income to budget. Add any income categories from your mint budget here
-let incomeCategories = [
+let incomeCategories = process.env.IMPORTER_INCOME_CATEGORIES?.split(',').map(cat => cat.trim()) || [
   "Paycheck",
   "Investment",
   "Returned Purchase",
@@ -22,6 +22,18 @@ let incomeCategories = [
 let api = require('@actual-app/api');
 const csvToJson = require('csv-parse/sync');
 const fs = require('fs');
+
+if (process.env.IMPORTER_EXTRA_INCOME_CATEGORIES) {
+  incomeCategories = [
+    ...incomeCategories,
+    ...process.env.IMPORTER_EXTRA_INCOME_CATEGORIES.split(',').map(cat => cat.trim())
+  ];
+}
+
+if (!password || !sync_id) {
+  console.error('Required settings not provided.');
+  process.exit(1);
+}
 
 const json = csvToJson.parse(fs.readFileSync(inFile, 'utf8'), {
   bom: true,


### PR DESCRIPTION
- Sets up for easy use within a docker container

Not everyone running actual-budget will have set it up via a working node dev environment. Some users will be just using the docker containers. Switching this to env variables will make it more friendly for throwing into a dockerfile. (I will followup with a Dockerfile PR)